### PR TITLE
the current kernel still needs a 3 GB RAM limit for the pi4.

### DIFF
--- a/_posts/2019-07-04-raspbian-rpi4-64.md
+++ b/_posts/2019-07-04-raspbian-rpi4-64.md
@@ -70,6 +70,13 @@ Kernel on 64bit had a memory size limitation due to the fact that only the first
 echo "total_mem=1024" >> /run/media/me/boot/config.txt
 ```
 
+Even in the current kernel there seems to be a bug that the USB ports are not working with 4 GB of RAM but the 64 bit kernel works fine with just 3 GB memory, see this [issue](https://github.com/raspberrypi/linux/issues/3093). So we should force the 3 GM ram by
+
+```sh
+echo "total_mem=3072" >> /run/media/me/boot/config.txt
+```
+
+
 The last piece in the jigsaw is forcing the firmware to set the arm in 64bit mode. This [should happen automatically](https://github.com/raspberrypi/firmware/issues/1193) based on the kernel image filename. Currently that doesn't seem to be stable so we will force it in the `config.txt`:
 
 
@@ -84,4 +91,4 @@ sync
 umount /run/media/me/boot
 ```
 
-In conclusion, if you are working on the latest Raspbian and the latest revision `4.19.y` kernel, all you need to do is force the arm in 64bit mode.
+In conclusion, if you are working on the latest Raspbian and the latest revision `4.19.y` kernel, all you need to do is force the arm in 64bit mode and an 3 GB memory limit as describe above.

--- a/_posts/2019-07-04-raspbian-rpi4-64.md
+++ b/_posts/2019-07-04-raspbian-rpi4-64.md
@@ -70,7 +70,7 @@ Kernel on 64bit had a memory size limitation due to the fact that only the first
 echo "total_mem=1024" >> /run/media/me/boot/config.txt
 ```
 
-Even in the current kernel there seems to be a bug that the USB ports are not working with 4 GB of RAM but the 64 bit kernel works fine with just 3 GB memory, see this [issue](https://github.com/raspberrypi/linux/issues/3093). So we should force the 3 GM ram by
+Even in the current kernel there seems to be a bug that the USB ports are not working with 4 GB of RAM but the 64 bit kernel works fine with just 3 GB memory, see this [issue](https://github.com/raspberrypi/linux/issues/3093). So we should limit the ram to 3 GB by
 
 ```sh
 echo "total_mem=3072" >> /run/media/me/boot/config.txt


### PR DESCRIPTION
See https://github.com/raspberrypi/linux/issues/3093