### PR TITLE
add Mastodon verification to site header

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,4 +14,6 @@
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}
+
+  <link rel="me" href="https://fosstodon.org/@ndrei">
 </head>


### PR DESCRIPTION
This is the non-visible version of the regular `rel=me` verification suggestions. Once changes have been deployed, you might have to re-save the profile on Mastodon so that verification checks are run again.